### PR TITLE
プロフィール表示のレイアウト作成

### DIFF
--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -16,7 +16,26 @@ class EventList extends StatelessWidget {
           padding: EdgeInsets.zero,
           children: [
             DrawerHeader(
-              child: Text(""),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(50)
+                    ),
+                    child: Image.asset(
+                      "assets/profile.png",
+                      height: 60,
+                    ),
+                  ),
+                  Container(
+                    margin: EdgeInsets.only(top: 10.0),
+                    child: Text("mh@mobiler", style: TextStyle(color: Colors.white),),
+                  )
+
+                ],
+              ),
               decoration: BoxDecoration(
                 color: Colors.blue,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/profile.png
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
# 概要

イベント一覧のDrawerにプロフィールを表示する。

# 変更内容

Drawerのヘッダーに以下を表示する。

- プロフィール画像
- プロフィール名

以下は未実装

- プロフィール画像やプロフィール名などをエンドポイントから取得する。

# 備考

プロフィール画像のアイコンは仮画像を設定

# 関連issue

#20 
