### PR TITLE
設定画面に遷移する前にDrawerを閉じる

### DIFF
--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -43,6 +43,7 @@ class EventList extends StatelessWidget {
             ListTile(
               title: Text("設定"),
               onTap: () {
+                Navigator.pop(context);
                 Navigator.push(context, MaterialPageRoute(builder: (context) {
                   return Settings();
                 }));


### PR DESCRIPTION
# 概要

#67 

# 変更内容

設定項目を押下時にNavigator.popを使って、Drawerを閉じる処理を追加

# 関連issue
