### PR TITLE
アプリ名を変更

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundleName</key>
-		<string>event_follow</string>
+		<string>Event Follow</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
# 概要

アプリ名を変更する。

# 変更内容

 ios/Runner/info.plistのKeyのCFBundleNameをEvent Followに変更した。

# 関連issue
