### PR TITLE
jwtトークンの更新処理

### DIFF
--- a/lib/repository/event_list_repository.dart
+++ b/lib/repository/event_list_repository.dart
@@ -3,9 +3,9 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 
 class EventListRepository {
-  final jwtToken;
+  final getOrGenerateIdToken;
 
-  EventListRepository({required this.jwtToken});
+  EventListRepository({required this.getOrGenerateIdToken});
 
   Future<EventListApiResults> requestEventListApi(
       {required EventListApiRequest request}) async {
@@ -16,7 +16,7 @@ class EventListRepository {
       url,
       headers: {
         HttpHeaders.contentTypeHeader: "application/json",
-        HttpHeaders.authorizationHeader: "Bearer ${this.jwtToken}"
+        HttpHeaders.authorizationHeader: "Bearer ${await this.getOrGenerateIdToken()}"
       },
     );
     return EventListApiResults.fromJson(json.decode(response.body));

--- a/lib/repository/following_tweets_repository.dart
+++ b/lib/repository/following_tweets_repository.dart
@@ -3,20 +3,22 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 
 class FollowingTweetsRepository {
-  final jwtToken;
+  final getOrGenerateIdToken;
 
-  FollowingTweetsRepository({required this.jwtToken});
+  FollowingTweetsRepository({required this.getOrGenerateIdToken});
 
   Future<FollowingTweetsApiResults> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {
     final url = Uri.https("event-follow-front.herokuapp.com",
         "/api/following_tweets", request.toParams());
 
+    print("jwtToken: ${await getOrGenerateIdToken()}");
+
     final response = await http.get(
       url,
       headers: {
         HttpHeaders.contentTypeHeader: "application/json",
-        HttpHeaders.authorizationHeader: "Bearer ${this.jwtToken}"
+        HttpHeaders.authorizationHeader: "Bearer ${await this.getOrGenerateIdToken()}"
       },
     );
 

--- a/lib/repository/following_tweets_repository.dart
+++ b/lib/repository/following_tweets_repository.dart
@@ -12,8 +12,6 @@ class FollowingTweetsRepository {
     final url = Uri.https("event-follow-front.herokuapp.com",
         "/api/following_tweets", request.toParams());
 
-    print("jwtToken: ${await getOrGenerateIdToken()}");
-
     final response = await http.get(
       url,
       headers: {

--- a/lib/repository/friendships_repository.dart
+++ b/lib/repository/friendships_repository.dart
@@ -3,9 +3,9 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 
 class FriendshipsRepository {
-  final jwtToken;
+  final getOrGenerateIdToken;
 
-  FriendshipsRepository({required this.jwtToken});
+  FriendshipsRepository({required this.getOrGenerateIdToken});
 
   Future<FriendshipsApiResults> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {
@@ -16,7 +16,7 @@ class FriendshipsRepository {
       url,
       headers: {
         HttpHeaders.contentTypeHeader: "application/json",
-        HttpHeaders.authorizationHeader: "Bearer ${this.jwtToken}"
+        HttpHeaders.authorizationHeader: "Bearer ${await this.getOrGenerateIdToken()}"
       },
     );
 

--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -102,8 +102,7 @@ class _EventListViewState extends State<EventListView> {
   }
 
   void initCardList() async {
-    final idToken = await firebaseAuth.currentUser?.getIdToken(true);
-    final eventListRepository = EventListRepository(jwtToken: idToken);
+    final eventListRepository = EventListRepository(getOrGenerateIdToken: firebaseAuth.currentUser?.getIdToken);
     final eventListApiRequest = EventListApiRequest(
         pageId: "1",
         sort: "friends_number_order",
@@ -115,7 +114,7 @@ class _EventListViewState extends State<EventListView> {
       _cardList.addAll(results.data.map((datum) {
         final event = datum.event;
         final extra = datum.extra;
-        return EventCard(event, extra, idToken!);
+        return EventCard(event, extra, firebaseAuth.currentUser?.getIdToken);
       }));
     });
   }
@@ -145,14 +144,14 @@ class _EventListViewState extends State<EventListView> {
 class EventCard extends StatelessWidget {
   final Event _event;
   final Extra _extra;
-  final String _jwtToken;
+  final _getOrGenerateIdToken;
   final FriendshipsRepository _friendshipsRepository;
   final FollowingTweetsRepository _followingTweetsRepository;
 
-  EventCard(this._event, this._extra, this._jwtToken)
-      : _friendshipsRepository = FriendshipsRepository(jwtToken: _jwtToken),
+  EventCard(this._event, this._extra, this._getOrGenerateIdToken)
+      : _friendshipsRepository = FriendshipsRepository(getOrGenerateIdToken: _getOrGenerateIdToken),
         _followingTweetsRepository =
-            FollowingTweetsRepository(jwtToken: _jwtToken);
+            FollowingTweetsRepository(getOrGenerateIdToken: _getOrGenerateIdToken);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -102,7 +102,7 @@ class _EventListViewState extends State<EventListView> {
   }
 
   void initCardList() async {
-    final idToken = await firebaseAuth.currentUser?.getIdToken();
+    final idToken = await firebaseAuth.currentUser?.getIdToken(true);
     final eventListRepository = EventListRepository(jwtToken: idToken);
     final eventListApiRequest = EventListApiRequest(
         pageId: "1",

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -51,7 +51,7 @@ class _HomeState extends State<Home> {
                         secret: authResult.authTokenSecret);
                     final firebaseCredential = await firebaseAuth.signInWithCredential(credential);
 
-                    final idToken = await firebaseCredential.user?.getIdToken();
+                    final idToken = await firebaseCredential.user?.getIdToken(true);
 
                     final request = SessionApiRequest(
                         token: idToken!,

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -51,7 +51,7 @@ class _HomeState extends State<Home> {
                         secret: authResult.authTokenSecret);
                     final firebaseCredential = await firebaseAuth.signInWithCredential(credential);
 
-                    final idToken = await firebaseCredential.user?.getIdToken(true);
+                    final idToken = await firebaseCredential.user?.getIdToken();
 
                     final request = SessionApiRequest(
                         token: idToken!,


### PR DESCRIPTION
# 概要

jwtトークンが期限切れの場合に401が発生するので、API通信で401が発生しないようにトークンを更新する。

# 変更内容

- FirebaseのcurrentUserのgetIdTokenメソッドをAPI通信を行う前に呼び出すように処理を追加した。
  - ただし、getIdToken(true)で強制リフレッシュすると毎回トークンが更新されるので、getIdToken(false)で期限切れの場合にリフレッシュする方式にした。


# 関連issue
