### PR TITLE
FirebaseAuthenticationのcurrentUserでログイン状態を判定

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -33,8 +33,6 @@ PODS:
   - flutter_inappwebview/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 5.0)
-  - flutter_secure_storage (3.3.1):
-    - Flutter
   - GoogleDataTransport (8.3.0):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30907.0)
@@ -72,7 +70,6 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
-  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - twitter_login (from `.symlinks/plugins/twitter_login/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
@@ -98,8 +95,6 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_inappwebview:
     :path: ".symlinks/plugins/flutter_inappwebview/ios"
-  flutter_secure_storage:
-    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   twitter_login:
     :path: ".symlinks/plugins/twitter_login/ios"
   url_launcher:
@@ -114,7 +109,6 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 066f996579cf097bdad3d7dc9a918d6b9e129c50
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
-  flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   GoogleDataTransport: b006084b73915a42c28a3466961a4edda3065da6
   GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,9 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import 'my_app.dart';
 
-final storage = FlutterSecureStorage();
 final firebaseAuth = FirebaseAuth.instance;
 
 Future<void> main() async {

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -1,47 +1,18 @@
 import 'package:event_follow/main.dart';
 import 'package:event_follow/ui/event_list.dart';
 import 'package:event_follow/ui/home.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class MyApp extends StatelessWidget {
-  Future<String> get jwtToken async {
-    final jwtToken = await storage.read(key: "jwt_token");
-    if (jwtToken == null) return "";
-    return jwtToken;
-  }
-
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: FutureBuilder(
-        future: jwtToken,
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return CircularProgressIndicator();
-          }
-
-          if (snapshot.data != "") {
-            final data = snapshot.data! as String;
-            final jwt = data.split(".");
-            if (jwt.length != 3) {
-              return Home();
-            }
-
-            return EventList();
-
-          } else {
-            return Home();
-          }
-
-        },
-      )
+      home: (firebaseAuth.currentUser != null) ? EventList() : Home(),
     );
   }
 }

--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -65,7 +65,6 @@ class EventList extends StatelessWidget {
               title: Text("ログアウト"),
               onTap: () {
                 firebaseAuth.signOut();
-                storage.delete(key: "jwt_token");
                 Navigator.pushReplacement(
                   context,
                   PageRouteBuilder(

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -1,7 +1,6 @@
 import 'package:event_follow/main.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -9,7 +8,6 @@ import 'package:http/http.dart' as http;
 import 'package:twitter_login/twitter_login.dart';
 import 'dart:convert';
 import 'event_list.dart';
-import 'package:event_follow/main.dart';
 
 class Home extends StatefulWidget {
   @override
@@ -61,7 +59,6 @@ class _HomeState extends State<Home> {
                     final sessionApiResults =
                         await requestSessionApi(request: request);
                     if (sessionApiResults.status == "OK") {
-                      storage.write(key: "jwt_token", value: idToken!);
                       Navigator.pushReplacement(context,
                           MaterialPageRoute(builder: (context) {
                         return EventList();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,13 +153,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.4+1"
-  flutter_secure_storage:
-    dependency: "direct main"
-    description:
-      name: flutter_secure_storage
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -380,4 +373,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.26.0-17.6.pre"
+  flutter: ">=1.22.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   firebase_core: ^1.0.1
   firebase_auth: ^1.0.1
   http: ^0.13.1
-  flutter_secure_storage: ^4.1.0
   intl: ^0.17.0
   flutter_linkify: ^5.0.0
   flutter_native_splash: ^1.1.4+1


### PR DESCRIPTION
# 概要

ログイン状態の判定処理をJWTトークンの有無で判定しないように処理を変更する。

# 変更内容

FirebaseAuthenticationで取得したJWTトークンを保存しログイン判定をしていたが、
FirebaseAuthenticationのcurrentUserでログイン判定を行うようにした。

# 関連issue
