### PR TITLE
EventListViewが親のCenterウィジェットでセンタリングしている不具合修正

### DIFF
--- a/lib/ui/event_list.dart
+++ b/lib/ui/event_list.dart
@@ -124,10 +124,8 @@ class EventList extends StatelessWidget {
           ],
         ),
       ),
-      body: Center(
-        child: EventListView(
-          key: eventListViewStateKey
-        ),
+      body: EventListView(
+        key: eventListViewStateKey
       ),
     );
   }


### PR DESCRIPTION
# 概要

イベント一覧が少ないデータの時にセンタリング表示される不具合を修正

# 変更内容

EventListViewの親のCenterウィジェットを削除した。

# 関連issue

#98 