### PR TITLE
reafactor: uiディレクトリのコンポーネントをevent_page配下に移動

### DIFF
--- a/lib/pages/events_pages/events_page.dart
+++ b/lib/pages/events_pages/events_page.dart
@@ -1,13 +1,13 @@
 import 'package:event_follow/models/controllers/events_controller/events_controller.dart';
 import 'package:event_follow/models/repositories/events/events_repository.dart';
 import 'package:event_follow/pages/events_pages/event_drawer_header.dart';
-import 'package:event_follow/ui/sort_filter_button.dart';
-import 'package:event_follow/ui/sort_filter_dialog.dart';
+import 'package:event_follow/pages/events_pages/sort_filter_button.dart';
+import 'package:event_follow/pages/events_pages/sort_filter_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import '../../config/sort_filter_globals.dart';
 import 'event_list_view.dart';
+import 'package:event_follow/config/sort_filter_globals.dart';
 
 final sortFilterStateKey = GlobalKey<SortFilterButtonState>();
 

--- a/lib/pages/events_pages/sort_filter_button.dart
+++ b/lib/pages/events_pages/sort_filter_button.dart
@@ -1,6 +1,6 @@
+import 'package:event_follow/config/sort_filter_globals.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import '../config/sort_filter_globals.dart';
 
 class SortFilterButton extends StatefulWidget {
   const SortFilterButton({

--- a/lib/pages/events_pages/sort_filter_dialog.dart
+++ b/lib/pages/events_pages/sort_filter_dialog.dart
@@ -1,6 +1,5 @@
-import 'package:event_follow/ui/sort_filter_button.dart';
+import 'package:event_follow/config/sort_filter_globals.dart';
 import 'package:flutter/material.dart';
-import '../config/sort_filter_globals.dart';
 
 typedef SortFilterDialogCallback = void Function(SortFilterStateStore store);
 


### PR DESCRIPTION
# 概要

uiディレクトリのコンポーネントをevent_page配下に移動する。

# 変更内容

 sort_filter_button.dartとsort_filter_dialog.dartをevents_page配下に移動した。

# 関連issue
