### PR TITLE
cached_network_imageを使った画像のキャッシュ処理

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -33,6 +33,9 @@ PODS:
   - flutter_inappwebview/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 5.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - GoogleDataTransport (8.3.0):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30907.0)
@@ -61,7 +64,12 @@ PODS:
   - OrderedSet (5.0.0)
   - package_info (0.0.1):
     - Flutter
+  - path_provider (0.0.1):
+    - Flutter
   - PromisesObjC (1.2.12)
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
   - twitter_login (0.0.1):
     - Flutter
   - url_launcher (0.0.1):
@@ -73,6 +81,8 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
+  - path_provider (from `.symlinks/plugins/path_provider/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - twitter_login (from `.symlinks/plugins/twitter_login/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
@@ -82,6 +92,7 @@ SPEC REPOS:
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FMDB
     - GoogleDataTransport
     - GoogleUtilities
     - GTMSessionFetcher
@@ -100,6 +111,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_inappwebview/ios"
   package_info:
     :path: ".symlinks/plugins/package_info/ios"
+  path_provider:
+    :path: ".symlinks/plugins/path_provider/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
   twitter_login:
     :path: ".symlinks/plugins/twitter_login/ios"
   url_launcher:
@@ -114,13 +129,16 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 066f996579cf097bdad3d7dc9a918d6b9e129c50
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   GoogleDataTransport: b006084b73915a42c28a3466961a4edda3065da6
   GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
+  path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   twitter_login: 2794db69b7640681171b17b3c2c84ad9dfb4a57f
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 

--- a/lib/pages/events_pages/event_card.dart
+++ b/lib/pages/events_pages/event_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:event_follow/models/entities/event.dart';
 import 'package:event_follow/models/entities/event_extra.dart';
 import 'package:event_follow/pages/events_pages/friends_footer.dart';
@@ -131,8 +132,13 @@ class EventCard extends HookWidget {
                                               CrossAxisAlignment.center,
                                               children: [
                                                 Container(
-                                                  child: Image.network(
-                                                    _event.banner,
+                                                  child: CachedNetworkImage(
+                                                    imageUrl: _event.banner,
+                                                    placeholder: (context, url) => Container(
+                                                      color: const Color(0xffd7d7d8),
+                                                      height: 50,
+                                                      width: 50,
+                                                    ),
                                                     height: 50,
                                                   ),
                                                 ),

--- a/lib/pages/events_pages/event_drawer_header.dart
+++ b/lib/pages/events_pages/event_drawer_header.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:event_follow/pages/home_pages/home_page.dart';
 import 'package:event_follow/pages/setting_pages/setting_page.dart';
 import 'package:flutter/cupertino.dart';
@@ -21,10 +22,14 @@ class EventDrawerHeader extends StatelessWidget {
                     child: Container(
                       child: ClipRRect(
                           borderRadius: BorderRadius.circular(50),
-                          child: Image.network(
-                            firebaseAuth.currentUser!.photoURL!,
+                          child: CachedNetworkImage(
+                            imageUrl: firebaseAuth.currentUser!.photoURL!,
+                            placeholder: (context, url) => Container(
+                              color: const Color(0xffd7d7d8),
+                            ),
                             fit: BoxFit.cover,
-                          )),
+                          ),
+                      ),
                     )),
                 Container(
                   margin: EdgeInsets.only(top: 10.0),

--- a/lib/pages/events_pages/following_tweets_list_view.dart
+++ b/lib/pages/events_pages/following_tweets_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:event_follow/models/controllers/following_tweets/following_tweets_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -55,8 +56,13 @@ class FollowingTweetsListView extends HookWidget {
                                   child: ClipRRect(
                                     borderRadius:
                                         BorderRadius.all(Radius.circular(50)),
-                                    child: Image.network(
-                                      tweet.user.profileImage,
+                                    child: CachedNetworkImage(
+                                      imageUrl: tweet.user.profileImage,
+                                      placeholder: (context, url) => Container(
+                                        color: const Color(0xffd7d7d8),
+                                        width: 30,
+                                        height: 30,
+                                      ),
                                       height: 30,
                                     ),
                                   ),

--- a/lib/pages/events_pages/friends_footer.dart
+++ b/lib/pages/events_pages/friends_footer.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:event_follow/models/controllers/following_tweets/following_tweets_controller.dart';
 import 'package:event_follow/models/controllers/friendships_controller/friendships_controller.dart';
 import 'package:event_follow/models/entities/event.dart';
@@ -40,19 +41,21 @@ class FriendsFooter extends HookWidget {
         children: [
           GestureDetector(
             onTap: () async {
-              followingTweetsController.request(FollowingTweetsApiRequest(eventId: this._event.id.toString()));
+              followingTweetsController.request(FollowingTweetsApiRequest(
+                  eventId: this._event.id.toString()));
 
               showModalBottomSheet(
                   context: context,
                   builder: (context) {
                     return Container(
                       constraints:
-                      BoxConstraints(minHeight: 100, maxHeight: 600),
+                          BoxConstraints(minHeight: 100, maxHeight: 600),
                       color: Colors.white,
-                      child: FollowingTweetsListView(eventId: this._event.id.toString(),),
+                      child: FollowingTweetsListView(
+                        eventId: this._event.id.toString(),
+                      ),
                     );
-                  }
-              );
+                  });
             },
             child: Container(
               margin: const EdgeInsets.only(right: 5.0),
@@ -71,26 +74,29 @@ class FriendsFooter extends HookWidget {
               ),
             ),
           ),
-          isLoading
-              ? SizedBox.shrink()
-              : Row(
-                  children: friends.map((friend) {
-                    return Container(
-                        margin: const EdgeInsets.only(right: 5.0),
-                        child: GestureDetector(
-                          onTap: () {
-                            launch("https://twitter.com/${friend.screenName}");
-                          },
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.all(Radius.circular(50)),
-                            child: Image.network(
-                              friend.profileImage,
-                              height: 30,
-                            ),
-                          ),
-                        ));
-                  }).toList(),
-                )
+          Row(
+            children: friends.map((friend) {
+              return Container(
+                  margin: const EdgeInsets.only(right: 5.0),
+                  child: GestureDetector(
+                    onTap: () {
+                      launch("https://twitter.com/${friend.screenName}");
+                    },
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.all(Radius.circular(50)),
+                      child: CachedNetworkImage(
+                        imageUrl: friend.profileImage,
+                        placeholder: (context, url) => Container(
+                          color: const Color(0xffd7d7d8),
+                          width: 30,
+                          height: 30,
+                        ),
+                        height: 30,
+                      ),
+                    ),
+                  ));
+            }).toList(),
+          )
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.4"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   characters:
     dependency: transitive
     description:
@@ -183,6 +190,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
@@ -244,6 +258,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -436,6 +464,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -457,6 +492,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   pedantic:
     dependency: transitive
     description:
@@ -471,6 +541,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -485,6 +562,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.1"
   pub_semver:
     dependency: transitive
     description:
@@ -506,6 +590,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.26.0"
   shelf:
     dependency: transitive
     description:
@@ -539,6 +630,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0+2"
   stack_trace:
     dependency: transitive
     description:
@@ -658,6 +763,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.3"
   vector_math:
     dependency: transitive
     description:
@@ -679,6 +791,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
@@ -695,4 +821,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.2"
+  flutter: ">=1.24.0-10.2.pre"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   hooks_riverpod: ^0.13.1+1
   freezed_annotation:
   synchronized: ^3.0.0
+  cached_network_image: ^3.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
# 概要

 cached_network_imageを使った画像のキャッシュ処理を実装する。

# 変更内容

 cached_network_imageのCachedNetworkImageのWidgetを使ってImage Widgetを置き換えた。
あわせて、placeholderの表示も追加した。

# 関連issue

#123
