### PR TITLE
APIクライアントをDIする

### DIFF
--- a/lib/models/api.dart
+++ b/lib/models/api.dart
@@ -1,7 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
+
+
+final apiClientProvider = Provider((_) => ApiClient());
 
 enum ApiInfo {
   SESSIONS,
@@ -36,7 +40,7 @@ abstract class ApiRequest {
   HttpMethod get httpMethod;
   String get baseDomain => "event-follow-front.herokuapp.com";
   Uri get uri => Uri.https(baseDomain, apiPath, toParams());
-  Map<String, String> get defaultHeaders => { HttpHeaders.authorizationHeader: "application/json" };
+  Map<String, String> get defaultHeaders => { HttpHeaders.contentTypeHeader: "application/json" };
   Map<String, String> toParams() => {};
   Map<String, dynamic> toJson() => {};
   void appendHeader(Map<String, String> appendedHeaders) {

--- a/lib/models/api.dart
+++ b/lib/models/api.dart
@@ -1,0 +1,29 @@
+enum ApiInfo {
+  SESSIONS,
+  USERS,
+  FRIENDSHIPS,
+  FOLLOWING_TWEETS,
+  EVENTS,
+}
+
+extension ApiInfoExtension on ApiInfo {
+  static final apiPaths = {
+    ApiInfo.SESSIONS: "/api/sessions",
+    ApiInfo.USERS: "/api/users",
+    ApiInfo.FRIENDSHIPS: "/api/friendships",
+    ApiInfo.FOLLOWING_TWEETS: "/api/following_tweets",
+    ApiInfo.EVENTS: "/api/events",
+  };
+
+  String get getApiPath => apiPaths[this]!;
+}
+
+abstract class ApiRequest {
+  String get getApiPath;
+}
+
+abstract class ApiClient {
+  final _baseUrl;
+
+  ApiClient({ required baseUrl }): _baseUrl = baseUrl ;
+}

--- a/lib/models/api.dart
+++ b/lib/models/api.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
 import '../main.dart';
@@ -36,7 +37,7 @@ abstract class ApiRequest {
   final getIdToken = firebaseAuth.currentUser?.getIdToken;
   String get apiPath;
   HttpMethod get httpMethod;
-  String get baseDomain => "event-follow-front.herokuapp.com";
+  String get baseDomain => env["BASE_DOMAIN"]!;
   Uri get uri => Uri.https(baseDomain, apiPath, toParams());
   bool get isAuthenticationReauired => false;
   Map<String, String> get defaultHeaders => { HttpHeaders.contentTypeHeader: "application/json" };

--- a/lib/models/controllers/events_controller/events_controller.dart
+++ b/lib/models/controllers/events_controller/events_controller.dart
@@ -2,7 +2,6 @@ import 'package:event_follow/config/sort_filter_globals.dart';
 import 'package:event_follow/models/repositories/events/events_api_request.dart';
 import 'package:event_follow/models/repositories/events/events_repository.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import '../../../main.dart';
 import 'events_state.dart';
 
 export 'events_state.dart';
@@ -18,8 +17,7 @@ class EventsController extends StateNotifier<EventsState> {
     state = state.copyWith(
       isLoading: false,
     );
-    final getIdToken = firebaseAuth.currentUser?.getIdToken;
-    _eventsRepository = this._read(eventsRepositoryProvider(getIdToken));
+    _eventsRepository = this._read(eventsRepositoryProvider);
 
     request(EventsApiRequest(pageId: "1"));
   }

--- a/lib/models/controllers/following_tweets/following_tweets_controller.dart
+++ b/lib/models/controllers/following_tweets/following_tweets_controller.dart
@@ -1,5 +1,4 @@
 import 'package:event_follow/models/repositories/following_tweets/following_tweets_api_request.dart';
-import '../../../main.dart';
 import '../../models.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'following_tweets_state.dart';
@@ -13,8 +12,7 @@ class FollowingTweetsController extends StateNotifier<FollowingTweetsState> {
     state = state.copyWith(
       isLoading: false,
     );
-    final getIdToken = firebaseAuth.currentUser?.getIdToken;
-    _followingTweetsRepository = this._read(followingTweetsRepositoryProvider(getIdToken));
+    _followingTweetsRepository = this._read(followingTweetsRepositoryProvider);
   }
 
   final Reader _read;

--- a/lib/models/controllers/friendships_controller/friendships_controller.dart
+++ b/lib/models/controllers/friendships_controller/friendships_controller.dart
@@ -10,8 +10,7 @@ StateNotifierProvider.autoDispose((ref) => FriendshipsController(ref.read));
 
 class FriendshipsController extends StateNotifier<FriendshipsState> {
   FriendshipsController(this._read) : super(FriendshipsState()) {
-    final getIdToken = firebaseAuth.currentUser?.getIdToken;
-    _friendshipsRepository = this._read(friendshipsRepositoryProvider(getIdToken));
+    _friendshipsRepository = this._read(friendshipsRepositoryProvider);
   }
 
   final Reader _read;

--- a/lib/models/controllers/users_controller/users_controller.dart
+++ b/lib/models/controllers/users_controller/users_controller.dart
@@ -1,4 +1,5 @@
 import 'package:event_follow/models/controllers/users_controller/users_state.dart';
+import 'package:event_follow/models/repositories/users/account_deletion_api_request.dart';
 
 import '../../../main.dart';
 import '../../models.dart';
@@ -24,7 +25,7 @@ class UsersController extends StateNotifier<UsersState> {
   late final UsersRepository _usersRepository;
 
   Future<void> requestAccountDeletion() async {
-    final usersApiResults = await _usersRepository.requestAccountDeletion();
+    final usersApiResults = await _usersRepository.requestAccountDeletion(AccountDeletionApiRequest());
     state = state.copyWith(
       status: usersApiResults.status == "OK" ? UsersStatus.OK : UsersStatus.NG,
     );

--- a/lib/models/controllers/users_controller/users_controller.dart
+++ b/lib/models/controllers/users_controller/users_controller.dart
@@ -1,7 +1,5 @@
 import 'package:event_follow/models/controllers/users_controller/users_state.dart';
 import 'package:event_follow/models/repositories/users/account_deletion_api_request.dart';
-
-import '../../../main.dart';
 import '../../models.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -17,8 +15,7 @@ class UsersController extends StateNotifier<UsersState> {
       isLoading: false,
     );
 
-    final getIdToken = firebaseAuth.currentUser?.getIdToken;
-    _usersRepository = this._read(usersRepositoryProvider(getIdToken));
+    _usersRepository = this._read(usersRepositoryProvider);
   }
 
   final Reader _read;

--- a/lib/models/repositories/events/events_api_request.dart
+++ b/lib/models/repositories/events/events_api_request.dart
@@ -1,6 +1,6 @@
 import 'package:event_follow/models/api.dart';
 
-class EventsApiRequest extends ApiRequest{
+class EventsApiRequest extends ApiRequest {
   final String pageId;
   final String? sort;
   final String? time;
@@ -14,11 +14,11 @@ class EventsApiRequest extends ApiRequest{
   });
 
   Map<String, String> toParams() => {
-    "page": this.pageId,
-    if (this.sort != null) "sort": this.sort!,
-    if (this.time != null) "time": this.time!,
-    if (this.friends != null) "friends": this.friends!,
-  };
+        "page": this.pageId,
+        if (this.sort != null) "sort": this.sort!,
+        if (this.time != null) "time": this.time!,
+        if (this.friends != null) "friends": this.friends!,
+      };
 
   @override
   bool get isAuthenticationReauired => true;

--- a/lib/models/repositories/events/events_api_request.dart
+++ b/lib/models/repositories/events/events_api_request.dart
@@ -1,4 +1,6 @@
-class EventsApiRequest {
+import 'package:event_follow/models/api.dart';
+
+class EventsApiRequest extends ApiRequest{
   final String pageId;
   final String? sort;
   final String? time;
@@ -17,4 +19,7 @@ class EventsApiRequest {
     if (this.time != null) "time": this.time!,
     if (this.friends != null) "friends": this.friends!,
   };
+
+  @override
+  String get getApiPath => ApiInfo.EVENTS.getApiPath;
 }

--- a/lib/models/repositories/events/events_api_request.dart
+++ b/lib/models/repositories/events/events_api_request.dart
@@ -21,6 +21,9 @@ class EventsApiRequest extends ApiRequest{
   };
 
   @override
+  bool get isAuthenticationReauired => true;
+
+  @override
   String get apiPath => ApiInfo.EVENTS.apiPath;
 
   @override

--- a/lib/models/repositories/events/events_api_request.dart
+++ b/lib/models/repositories/events/events_api_request.dart
@@ -21,5 +21,8 @@ class EventsApiRequest extends ApiRequest{
   };
 
   @override
-  String get getApiPath => ApiInfo.EVENTS.getApiPath;
+  String get apiPath => ApiInfo.EVENTS.apiPath;
+
+  @override
+  HttpMethod get httpMethod => HttpMethod.GET;
 }

--- a/lib/models/repositories/events/events_repository.dart
+++ b/lib/models/repositories/events/events_repository.dart
@@ -17,7 +17,7 @@ class EventsRepository {
   Future<EventsApiResponse> requestEventsApi(
       {required EventsApiRequest request}) async {
     final url = Uri.https(
-        "event-follow-front.herokuapp.com", "/api/events", request.toParams());
+        "event-follow-front.herokuapp.com", request.getApiPath, request.toParams());
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/events/events_repository.dart
+++ b/lib/models/repositories/events/events_repository.dart
@@ -1,19 +1,16 @@
 import 'dart:convert';
-import 'dart:io';
 import 'package:event_follow/models/api.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'events_api_request.dart';
 import 'events_api_response.dart';
 
-final eventsRepositoryProvider = Provider.autoDispose
-    .family<EventsRepository, dynamic>((ref, getOrGenerateIdToken) =>
-        EventsRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
+final eventsRepositoryProvider = Provider.autoDispose<EventsRepository>((ref) =>
+        EventsRepository(read: ref.read));
 
 class EventsRepository {
-  final getOrGenerateIdToken;
   final Reader read;
 
-  EventsRepository({required this.getOrGenerateIdToken, required this.read});
+  EventsRepository({required this.read});
 
   Future<EventsApiResponse> requestEventsApi(
       {required EventsApiRequest request}) async {

--- a/lib/models/repositories/events/events_repository.dart
+++ b/lib/models/repositories/events/events_repository.dart
@@ -16,8 +16,7 @@ class EventsRepository {
 
   Future<EventsApiResponse> requestEventsApi(
       {required EventsApiRequest request}) async {
-    final url = Uri.https(
-        "event-follow-front.herokuapp.com", request.getApiPath, request.toParams());
+    final url = request.uri;
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/events/events_repository.dart
+++ b/lib/models/repositories/events/events_repository.dart
@@ -18,11 +18,6 @@ class EventsRepository {
   Future<EventsApiResponse> requestEventsApi(
       {required EventsApiRequest request}) async {
 
-    request.appendHeader({
-      HttpHeaders.authorizationHeader: "Bearer ${await this
-          .getOrGenerateIdToken()}"
-    });
-
     final apiClient = read(apiClientProvider);
     final response = await apiClient.request(request);
     return EventsApiResponse.fromJson(json.decode(response.body));

--- a/lib/models/repositories/following_tweets/following_tweets_api_request.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_api_request.dart
@@ -12,6 +12,9 @@ class FollowingTweetsApiRequest extends ApiRequest {
   };
 
   @override
+  bool get isAuthenticationReauired => true;
+
+  @override
   String get apiPath => ApiInfo.FOLLOWING_TWEETS.apiPath;
 
   @override

--- a/lib/models/repositories/following_tweets/following_tweets_api_request.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_api_request.dart
@@ -12,5 +12,8 @@ class FollowingTweetsApiRequest extends ApiRequest {
   };
 
   @override
-  String get getApiPath => ApiInfo.FOLLOWING_TWEETS.getApiPath;
+  String get apiPath => ApiInfo.FOLLOWING_TWEETS.apiPath;
+
+  @override
+  HttpMethod get httpMethod => HttpMethod.GET;
 }

--- a/lib/models/repositories/following_tweets/following_tweets_api_request.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_api_request.dart
@@ -1,4 +1,6 @@
-class FollowingTweetsApiRequest {
+import 'package:event_follow/models/api.dart';
+
+class FollowingTweetsApiRequest extends ApiRequest {
   final String eventId;
 
   FollowingTweetsApiRequest({
@@ -8,4 +10,7 @@ class FollowingTweetsApiRequest {
   Map<String, String> toParams() => {
     "event_id": this.eventId,
   };
+
+  @override
+  String get getApiPath => ApiInfo.FOLLOWING_TWEETS.getApiPath;
 }

--- a/lib/models/repositories/following_tweets/following_tweets_repository.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_repository.dart
@@ -17,11 +17,6 @@ class FollowingTweetsRepository {
   Future<FollowingTweetsApiResponse> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {
 
-    request.appendHeader({
-      HttpHeaders.authorizationHeader: "Bearer ${await this
-          .getOrGenerateIdToken()}"
-    });
-
     final apiClient = read(apiClientProvider);
     final response = await apiClient.request(request);
     return FollowingTweetsApiResponse.fromJson(json.decode(response.body));

--- a/lib/models/repositories/following_tweets/following_tweets_repository.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_repository.dart
@@ -1,30 +1,29 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:http/http.dart' as http;
+import '../../api.dart';
 import 'following_tweets_api_request.dart';
 import 'following_tweets_api_response.dart';
 
 final followingTweetsRepositoryProvider = Provider.autoDispose.family<FollowingTweetsRepository, dynamic>(
-        (ref, getOrGenerateIdToken) => FollowingTweetsRepository(getOrGenerateIdToken: getOrGenerateIdToken));
+        (ref, getOrGenerateIdToken) => FollowingTweetsRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
 
 class FollowingTweetsRepository {
   final getOrGenerateIdToken;
+  final Reader read;
 
-  FollowingTweetsRepository({required this.getOrGenerateIdToken});
+  FollowingTweetsRepository({required this.getOrGenerateIdToken, required this.read});
 
   Future<FollowingTweetsApiResponse> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {
-    final url = request.uri;
 
-    final response = await http.get(
-      url,
-      headers: {
-        HttpHeaders.contentTypeHeader: "application/json",
-        HttpHeaders.authorizationHeader: "Bearer ${await this.getOrGenerateIdToken()}"
-      },
-    );
+    request.appendHeader({
+      HttpHeaders.authorizationHeader: "Bearer ${await this
+          .getOrGenerateIdToken()}"
+    });
 
+    final apiClient = read(apiClientProvider);
+    final response = await apiClient.request(request);
     return FollowingTweetsApiResponse.fromJson(json.decode(response.body));
   }
 }

--- a/lib/models/repositories/following_tweets/following_tweets_repository.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_repository.dart
@@ -16,7 +16,7 @@ class FollowingTweetsRepository {
   Future<FollowingTweetsApiResponse> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {
     final url = Uri.https("event-follow-front.herokuapp.com",
-        "/api/following_tweets", request.toParams());
+        request.getApiPath, request.toParams());
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/following_tweets/following_tweets_repository.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_repository.dart
@@ -15,8 +15,7 @@ class FollowingTweetsRepository {
 
   Future<FollowingTweetsApiResponse> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {
-    final url = Uri.https("event-follow-front.herokuapp.com",
-        request.getApiPath, request.toParams());
+    final url = request.uri;
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/following_tweets/following_tweets_repository.dart
+++ b/lib/models/repositories/following_tweets/following_tweets_repository.dart
@@ -5,14 +5,13 @@ import '../../api.dart';
 import 'following_tweets_api_request.dart';
 import 'following_tweets_api_response.dart';
 
-final followingTweetsRepositoryProvider = Provider.autoDispose.family<FollowingTweetsRepository, dynamic>(
-        (ref, getOrGenerateIdToken) => FollowingTweetsRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
+final followingTweetsRepositoryProvider = Provider.autoDispose<FollowingTweetsRepository>(
+        (ref) => FollowingTweetsRepository(read: ref.read));
 
 class FollowingTweetsRepository {
-  final getOrGenerateIdToken;
   final Reader read;
 
-  FollowingTweetsRepository({required this.getOrGenerateIdToken, required this.read});
+  FollowingTweetsRepository({required this.read});
 
   Future<FollowingTweetsApiResponse> requestFollowingTweetsApi(
       {required FollowingTweetsApiRequest request}) async {

--- a/lib/models/repositories/friendships/friendships_api_request.dart
+++ b/lib/models/repositories/friendships/friendships_api_request.dart
@@ -1,4 +1,6 @@
-class FriendshipsApiRequest {
+import 'package:event_follow/models/api.dart';
+
+class FriendshipsApiRequest extends ApiRequest {
   final String userIds;
 
   FriendshipsApiRequest({
@@ -8,4 +10,7 @@ class FriendshipsApiRequest {
   Map<String, String> toParams() => {
         "user_ids": this.userIds,
       };
+
+  @override
+  String get getApiPath => ApiInfo.FRIENDSHIPS.getApiPath;
 }

--- a/lib/models/repositories/friendships/friendships_api_request.dart
+++ b/lib/models/repositories/friendships/friendships_api_request.dart
@@ -12,5 +12,8 @@ class FriendshipsApiRequest extends ApiRequest {
       };
 
   @override
-  String get getApiPath => ApiInfo.FRIENDSHIPS.getApiPath;
+  String get apiPath => ApiInfo.FRIENDSHIPS.apiPath;
+
+  @override
+  HttpMethod get httpMethod => HttpMethod.GET;
 }

--- a/lib/models/repositories/friendships/friendships_api_request.dart
+++ b/lib/models/repositories/friendships/friendships_api_request.dart
@@ -12,6 +12,9 @@ class FriendshipsApiRequest extends ApiRequest {
       };
 
   @override
+  bool get isAuthenticationReauired => true;
+
+  @override
   String get apiPath => ApiInfo.FRIENDSHIPS.apiPath;
 
   @override

--- a/lib/models/repositories/friendships/friendships_repository.dart
+++ b/lib/models/repositories/friendships/friendships_repository.dart
@@ -15,8 +15,7 @@ class FriendshipsRepository {
 
   Future<FriendshipsApiResponse> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {
-    final url = Uri.https("event-follow-front.herokuapp.com",
-        request.getApiPath, request.toParams());
+    final url = request.uri;
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/friendships/friendships_repository.dart
+++ b/lib/models/repositories/friendships/friendships_repository.dart
@@ -5,14 +5,13 @@ import '../../api.dart';
 import 'friendships_api_request.dart';
 import 'friendships_api_response.dart';
 
-final friendshipsRepositoryProvider = Provider.autoDispose.family<FriendshipsRepository, dynamic>(
-        (ref, getOrGenerateIdToken) => FriendshipsRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
+final friendshipsRepositoryProvider = Provider.autoDispose<FriendshipsRepository>(
+        (ref) => FriendshipsRepository(read: ref.read));
 
 class FriendshipsRepository {
-  final getOrGenerateIdToken;
   final Reader read;
 
-  FriendshipsRepository({required this.getOrGenerateIdToken, required this.read});
+  FriendshipsRepository({required this.read});
 
   Future<FriendshipsApiResponse> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {

--- a/lib/models/repositories/friendships/friendships_repository.dart
+++ b/lib/models/repositories/friendships/friendships_repository.dart
@@ -1,29 +1,29 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:http/http.dart' as http;
+import '../../api.dart';
 import 'friendships_api_request.dart';
 import 'friendships_api_response.dart';
 
 final friendshipsRepositoryProvider = Provider.autoDispose.family<FriendshipsRepository, dynamic>(
-        (ref, getOrGenerateIdToken) => FriendshipsRepository(getOrGenerateIdToken: getOrGenerateIdToken));
+        (ref, getOrGenerateIdToken) => FriendshipsRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
 
 class FriendshipsRepository {
   final getOrGenerateIdToken;
+  final Reader read;
 
-  FriendshipsRepository({required this.getOrGenerateIdToken});
+  FriendshipsRepository({required this.getOrGenerateIdToken, required this.read});
 
   Future<FriendshipsApiResponse> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {
-    final url = request.uri;
 
-    final response = await http.get(
-      url,
-      headers: {
-        HttpHeaders.contentTypeHeader: "application/json",
-        HttpHeaders.authorizationHeader: "Bearer ${await this.getOrGenerateIdToken()}"
-      },
-    );
+    request.appendHeader({
+      HttpHeaders.authorizationHeader: "Bearer ${await this
+          .getOrGenerateIdToken()}"
+    });
+
+    final apiClient = read(apiClientProvider);
+    final response = await apiClient.request(request);
 
     return FriendshipsApiResponse.fromJson(json.decode(response.body));
   }

--- a/lib/models/repositories/friendships/friendships_repository.dart
+++ b/lib/models/repositories/friendships/friendships_repository.dart
@@ -17,11 +17,6 @@ class FriendshipsRepository {
   Future<FriendshipsApiResponse> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {
 
-    request.appendHeader({
-      HttpHeaders.authorizationHeader: "Bearer ${await this
-          .getOrGenerateIdToken()}"
-    });
-
     final apiClient = read(apiClientProvider);
     final response = await apiClient.request(request);
 

--- a/lib/models/repositories/friendships/friendships_repository.dart
+++ b/lib/models/repositories/friendships/friendships_repository.dart
@@ -16,7 +16,7 @@ class FriendshipsRepository {
   Future<FriendshipsApiResponse> requestFriendshipsApi(
       {required FriendshipsApiRequest request}) async {
     final url = Uri.https("event-follow-front.herokuapp.com",
-        "/api/friendships", request.toParams());
+        request.getApiPath, request.toParams());
 
     final response = await http.get(
       url,

--- a/lib/models/repositories/sessions/sessions_api_request.dart
+++ b/lib/models/repositories/sessions/sessions_api_request.dart
@@ -1,4 +1,6 @@
-class SessionsApiRequest {
+import 'package:event_follow/models/api.dart';
+
+class SessionsApiRequest extends ApiRequest {
   final String token;
   final String accessToken;
   final String accessTokenSecret;
@@ -14,4 +16,7 @@ class SessionsApiRequest {
     "access_token": this.accessToken,
     "access_token_secret": this.accessTokenSecret,
   };
+
+  @override
+  String get getApiPath => ApiInfo.SESSIONS.getApiPath;
 }

--- a/lib/models/repositories/sessions/sessions_api_request.dart
+++ b/lib/models/repositories/sessions/sessions_api_request.dart
@@ -18,5 +18,9 @@ class SessionsApiRequest extends ApiRequest {
   };
 
   @override
-  String get getApiPath => ApiInfo.SESSIONS.getApiPath;
+  String get apiPath => ApiInfo.SESSIONS.apiPath;
+
+  @override
+  HttpMethod get httpMethod => HttpMethod.POST;
+
 }

--- a/lib/models/repositories/sessions/sessions_repository.dart
+++ b/lib/models/repositories/sessions/sessions_repository.dart
@@ -13,8 +13,7 @@ class SessionsRepository {
 
   Future<SessionsApiResponse> requestSessionsApi(
       {required SessionsApiRequest request}) async {
-    final url = Uri.https("event-follow-front.herokuapp.com",
-        request.getApiPath);
+    final url = request.uri;
 
     final response = await http.post(
       url,

--- a/lib/models/repositories/sessions/sessions_repository.dart
+++ b/lib/models/repositories/sessions/sessions_repository.dart
@@ -13,8 +13,9 @@ class SessionsRepository {
 
   Future<SessionsApiResponse> requestSessionsApi(
       {required SessionsApiRequest request}) async {
-    final url =
-    Uri.parse("https://event-follow-front.herokuapp.com/api/sessions");
+    final url = Uri.https("event-follow-front.herokuapp.com",
+        request.getApiPath);
+
     final response = await http.post(
       url,
       body: json.encode(request.toJson()),

--- a/lib/models/repositories/sessions/sessions_repository.dart
+++ b/lib/models/repositories/sessions/sessions_repository.dart
@@ -1,25 +1,22 @@
 import 'dart:convert';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:http/http.dart' as http;
+import '../../api.dart';
 import 'sessions_api_request.dart';
 import 'sessions_api_response.dart';
 
 final sessionsRepositoryProvider = Provider.autoDispose(
-        (ref) => SessionsRepository());
+        (ref) => SessionsRepository(read: ref.read));
 
 class SessionsRepository {
 
-  SessionsRepository();
+  final Reader read;
+  SessionsRepository({ required this.read });
 
   Future<SessionsApiResponse> requestSessionsApi(
       {required SessionsApiRequest request}) async {
-    final url = request.uri;
 
-    final response = await http.post(
-      url,
-      body: json.encode(request.toJson()),
-      headers: {"Content-Type": "application/json"},
-    );
+    final apiClient = read(apiClientProvider);
+    final response = await apiClient.request(request);
 
     if (response.statusCode == 200) {
       return SessionsApiResponse.fromJson(json.decode(response.body));

--- a/lib/models/repositories/users/account_deletion_api_request.dart
+++ b/lib/models/repositories/users/account_deletion_api_request.dart
@@ -4,6 +4,9 @@ class AccountDeletionApiRequest extends ApiRequest {
   AccountDeletionApiRequest();
 
   @override
+  bool get isAuthenticationReauired => true;
+
+  @override
   String get apiPath => ApiInfo.USERS.apiPath;
 
   @override

--- a/lib/models/repositories/users/account_deletion_api_request.dart
+++ b/lib/models/repositories/users/account_deletion_api_request.dart
@@ -1,0 +1,8 @@
+import 'package:event_follow/models/api.dart';
+
+class AccountDeletionApiRequest extends ApiRequest {
+  AccountDeletionApiRequest();
+
+  @override
+  String get getApiPath => ApiInfo.USERS.getApiPath;
+}

--- a/lib/models/repositories/users/account_deletion_api_request.dart
+++ b/lib/models/repositories/users/account_deletion_api_request.dart
@@ -4,5 +4,8 @@ class AccountDeletionApiRequest extends ApiRequest {
   AccountDeletionApiRequest();
 
   @override
-  String get getApiPath => ApiInfo.USERS.getApiPath;
+  String get apiPath => ApiInfo.USERS.apiPath;
+
+  @override
+  HttpMethod get httpMethod => HttpMethod.DELETE;
 }

--- a/lib/models/repositories/users/account_deletion_api_response.dart
+++ b/lib/models/repositories/users/account_deletion_api_response.dart
@@ -1,12 +1,9 @@
 import 'package:event_follow/models/api.dart';
 
-class AccountDeletionApiResponse extends ApiRequest {
+class AccountDeletionApiResponse {
   final String status;
 
   AccountDeletionApiResponse({
     required this.status,
   });
-
-  @override
-  String get getApiPath => ApiInfo.USERS.getApiPath;
 }

--- a/lib/models/repositories/users/account_deletion_api_response.dart
+++ b/lib/models/repositories/users/account_deletion_api_response.dart
@@ -1,7 +1,12 @@
-class AccountDeletionApiResponse {
+import 'package:event_follow/models/api.dart';
+
+class AccountDeletionApiResponse extends ApiRequest {
   final String status;
 
   AccountDeletionApiResponse({
     required this.status,
   });
+
+  @override
+  String get getApiPath => ApiInfo.USERS.getApiPath;
 }

--- a/lib/models/repositories/users/users_repository.dart
+++ b/lib/models/repositories/users/users_repository.dart
@@ -15,11 +15,6 @@ class UsersRepository {
 
   Future<AccountDeletionApiResponse> requestAccountDeletion(AccountDeletionApiRequest request) async {
 
-    request.appendHeader({
-      HttpHeaders.authorizationHeader: "Bearer ${await this
-          .getOrGenerateIdToken()}"
-    });
-
     final apiClient = read(apiClientProvider);
     final response = await apiClient.request(request);
 

--- a/lib/models/repositories/users/users_repository.dart
+++ b/lib/models/repositories/users/users_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'account_deletion_api_request.dart';
 import 'account_deletion_api_response.dart';
 
 final usersRepositoryProvider = Provider.autoDispose.family<UsersRepository, dynamic>(
@@ -11,8 +12,8 @@ class UsersRepository {
 
   UsersRepository({required this.getOrGenerateIdToken});
 
-  Future<AccountDeletionApiResponse> requestAccountDeletion() async {
-    final url = Uri.https("event-follow-front.herokuapp.com", "/api/users");
+  Future<AccountDeletionApiResponse> requestAccountDeletion(AccountDeletionApiRequest request) async {
+    final url = Uri.https("event-follow-front.herokuapp.com", request.getApiPath);
 
     final response = await http.delete(
       url,

--- a/lib/models/repositories/users/users_repository.dart
+++ b/lib/models/repositories/users/users_repository.dart
@@ -4,14 +4,13 @@ import '../../api.dart';
 import 'account_deletion_api_request.dart';
 import 'account_deletion_api_response.dart';
 
-final usersRepositoryProvider = Provider.autoDispose.family<UsersRepository, dynamic>(
-        (ref, getOrGenerateIdToken) => UsersRepository(getOrGenerateIdToken: getOrGenerateIdToken, read: ref.read));
+final usersRepositoryProvider = Provider.autoDispose<UsersRepository>(
+        (ref) => UsersRepository(read: ref.read));
 
 class UsersRepository {
-  final getOrGenerateIdToken;
   final Reader read;
 
-  UsersRepository({required this.getOrGenerateIdToken, required this.read});
+  UsersRepository({required this.read});
 
   Future<AccountDeletionApiResponse> requestAccountDeletion(AccountDeletionApiRequest request) async {
 

--- a/lib/models/repositories/users/users_repository.dart
+++ b/lib/models/repositories/users/users_repository.dart
@@ -13,7 +13,7 @@ class UsersRepository {
   UsersRepository({required this.getOrGenerateIdToken});
 
   Future<AccountDeletionApiResponse> requestAccountDeletion(AccountDeletionApiRequest request) async {
-    final url = Uri.https("event-follow-front.herokuapp.com", request.getApiPath);
+    final url = request.uri;
 
     final response = await http.delete(
       url,


### PR DESCRIPTION
# 概要

APIクライアントをDIする

# 変更内容

- APIクラインアントの実装
- APIクライアントをリポジトリにDIするように変更
- リクエスト情報をリクエストクラスから構築するように変更
- API認証の有無をリクエストクラスで判定
- 認証トークンの生成をリクエストクラスで実施
- APIのベースドメインを.envから取得

# 関連issue

#2 