### PR TITLE
CahcedNetwordImageの画像表示の改善

### DIFF
--- a/lib/pages/events_pages/event_card.dart
+++ b/lib/pages/events_pages/event_card.dart
@@ -134,11 +134,11 @@ class EventCard extends HookWidget {
                                                 Container(
                                                   child: CachedNetworkImage(
                                                     imageUrl: _event.banner,
-                                                    placeholder: (context, url) => Container(
-                                                      color: const Color(0xffd7d7d8),
-                                                      height: 50,
-                                                      width: 50,
-                                                    ),
+                                                    errorWidget: (_, __, ___) {
+                                                      return Container(
+                                                        color: const Color(0xffd7d7d8),
+                                                      );
+                                                    },
                                                     height: 50,
                                                   ),
                                                 ),

--- a/lib/pages/events_pages/event_drawer_header.dart
+++ b/lib/pages/events_pages/event_drawer_header.dart
@@ -22,11 +22,8 @@ class EventDrawerHeader extends StatelessWidget {
                     child: Container(
                       child: ClipRRect(
                           borderRadius: BorderRadius.circular(50),
-                          child: CachedNetworkImage(
-                            imageUrl: firebaseAuth.currentUser!.photoURL!,
-                            placeholder: (context, url) => Container(
-                              color: const Color(0xffd7d7d8),
-                            ),
+                          child: Image.network(
+                            firebaseAuth.currentUser!.photoURL!,
                             fit: BoxFit.cover,
                           ),
                       ),

--- a/lib/pages/events_pages/following_tweets_list_view.dart
+++ b/lib/pages/events_pages/following_tweets_list_view.dart
@@ -63,6 +63,13 @@ class FollowingTweetsListView extends HookWidget {
                                         width: 30,
                                         height: 30,
                                       ),
+                                      errorWidget: (_, __, ___) {
+                                        return Container(
+                                          color: const Color(0xffd7d7d8),
+                                          width: 30,
+                                          height: 30,
+                                        );
+                                      },
                                       height: 30,
                                     ),
                                   ),

--- a/lib/pages/events_pages/friends_footer.dart
+++ b/lib/pages/events_pages/friends_footer.dart
@@ -91,6 +91,13 @@ class FriendsFooter extends HookWidget {
                           width: 30,
                           height: 30,
                         ),
+                        errorWidget: (_, __, ___) {
+                          return Container(
+                            color: const Color(0xffd7d7d8),
+                            width: 30,
+                            height: 30,
+                          );
+                        },
                         height: 30,
                       ),
                     ),


### PR DESCRIPTION
# 概要

CahcedNetwordImageの画像表示の改善する。

# 変更内容

以下を対応した。

-  イベントバナーのplaceholderが合わないので、イベントバナーのplaceholderは削除
- ログインユーザーのプロフィールアイコンの表示が崩れるため、プロフィールアイコンのplaceholderは削除
-  画像の403ステータス時に代替ビューを追加


# 関連issue
