### PR TITLE
ログインエラーのハンドリング処理

### DIFF
--- a/lib/models/controllers/sessions_controller/sessions_controller.dart
+++ b/lib/models/controllers/sessions_controller/sessions_controller.dart
@@ -1,3 +1,4 @@
+import 'package:event_follow/models/controllers/sessions_controller/sessions_state.dart';
 import 'package:event_follow/models/repositories/sessions/sessions_api_request.dart';
 import '../../models.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,12 +22,22 @@ class SessionsController extends StateNotifier<SessionsState> {
   late final SessionsRepository _sessionsRepository;
 
   Future<void> request(SessionsApiRequest request) async {
-
-    final sessionApiResults =
-    await _sessionsRepository.requestSessionsApi(request: request);
     state = state.copyWith(
-      status: sessionApiResults.status == "OK" ? SessionsStatus.OK : SessionsStatus.NG,
+      status: SessionsStatus.NONE,
     );
+
+    try {
+      final sessionApiResults = await _sessionsRepository.requestSessionsApi(request: request);
+      state = state.copyWith(
+        status: sessionApiResults.status == "OK" ? SessionsStatus.OK : SessionsStatus.NG,
+      );
+    } on Exception {
+      state = state.copyWith(
+        isLoading: false,
+        status: SessionsStatus.NG,
+      );
+    }
+
   }
 
   void setLoading(bool isLoading) {

--- a/lib/models/controllers/sessions_controller/sessions_state.dart
+++ b/lib/models/controllers/sessions_controller/sessions_state.dart
@@ -4,14 +4,15 @@ import 'package:flutter/foundation.dart';
 part 'sessions_state.freezed.dart';
 
 enum SessionsStatus {
+  NONE,
   OK,
-  NG
+  NG,
 }
 
 @freezed
 abstract class SessionsState with _$SessionsState {
   factory SessionsState({
-    @Default(SessionsStatus.NG) SessionsStatus status,
+    @Default(SessionsStatus.NONE) SessionsStatus status,
     @Default(false) bool isLoading,
   }) = _SessionsState;
 

--- a/lib/pages/home_pages/home_page.dart
+++ b/lib/pages/home_pages/home_page.dart
@@ -10,8 +10,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'home_logo.dart';
 
-final _shouldPush = Provider.autoDispose(
-    (ref) => ref.watch(sessionsProvider.state).status == SessionsStatus.OK);
+final _sessionStateProvider = Provider.autoDispose<SessionsStatus>(
+    (ref) => ref.watch(sessionsProvider.state).status);
 
 class HomePage extends HookWidget {
   @override
@@ -20,13 +20,34 @@ class HomePage extends HookWidget {
         useProvider(sessionsProvider.state.select((value) => value.isLoading));
 
     return ProviderListener(
-      provider: _shouldPush,
-      onChange: (context, bool shouldPush) {
-        if (shouldPush) {
-          Navigator.pushReplacement(context,
-              MaterialPageRoute(builder: (context) {
-                return EventsPage();
-              }));
+      provider: _sessionStateProvider,
+      onChange: (context, SessionsStatus sessionsStatus) async {
+        switch (sessionsStatus) {
+          case SessionsStatus.OK:
+            Navigator.pushReplacement(context,
+                MaterialPageRoute(builder: (context) {
+              return EventsPage();
+            }));
+            break;
+          case SessionsStatus.NG:
+            await showDialog(
+              context: context,
+              builder: (BuildContext context) => new AlertDialog(
+                title: new Text("確認"),
+                content: new Text("ログインエラーが発生しました。\n再度お試しください。"),
+                actions: <Widget>[
+                  new SimpleDialogOption(
+                    child: new Text("OK"),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              ),
+            );
+            break;
+          default:
+            break;
         }
       },
       child: Scaffold(


### PR DESCRIPTION
# 概要

ログインエラーのハンドリングを行う。

# 変更内容

ログインエラー時に何も起きないため、エラーアラートを表示するようにした。

# 対応方法

ログイン状態をステータス管理し、ステータスの状態がNGに変更されたことをProviderListenerで検知しエラーアラートを表示するようにした。

# 関連issue

#128 
