### PR TITLE
ログイン直後にエラーアラートが表示される不具合を修正

### DIFF
--- a/lib/models/controllers/sessions_controller/sessions_controller.dart
+++ b/lib/models/controllers/sessions_controller/sessions_controller.dart
@@ -10,7 +10,7 @@ final sessionsProvider = StateNotifierProvider.autoDispose((ref) => SessionsCont
 class SessionsController extends StateNotifier<SessionsState> {
   SessionsController(this._read): super(SessionsState()) {
     state = state.copyWith(
-      status: SessionsStatus.NG,
+      status: SessionsStatus.NONE,
       isLoading: false,
     );
 


### PR DESCRIPTION
# 概要

ログイン直後にエラーアラートが表示される不具合を修正する。

# 変更内容

ログインリクエストの初期化時にステータスをNGに変更していたのが原因なので、ステータスをNONEに変更した。

# 関連issue
