### PR TITLE
feat: イベント一覧のトップスクロール用のボタンを追加

### DIFF
--- a/lib/models/controllers/events_controller/events_controller.dart
+++ b/lib/models/controllers/events_controller/events_controller.dart
@@ -7,8 +7,19 @@ import 'events_state.dart';
 
 export 'events_state.dart';
 
+const eventsTopScrollButtonVisiblePosition = 800.0;
+const initialPageId = '1';
+
 final eventsConditionProvider =
     StateProvider.autoDispose<SortFilterStateStore?>((ref) => null);
+
+final eventsScrollPositionProvider =
+    StateProvider.autoDispose<double>((ref) => 0.0);
+
+final eventsTopScrollButtonVisibilityProvider = Provider.autoDispose<bool>(
+    (ref) =>
+        ref.watch(eventsScrollPositionProvider).state >
+        eventsTopScrollButtonVisiblePosition);
 
 final eventsProvider =
     StateNotifierProvider.autoDispose((ref) => EventsController(ref.read));
@@ -20,7 +31,7 @@ class EventsController extends StateNotifier<EventsState> {
     );
     _eventsRepository = _read(eventsRepositoryProvider);
 
-    request(EventsApiRequest(pageId: '1'));
+    request(EventsApiRequest(pageId: initialPageId));
   }
 
   final Reader _read;
@@ -31,7 +42,7 @@ class EventsController extends StateNotifier<EventsState> {
       isLoading: true,
     );
 
-    if (request.pageId == '1') {
+    if (request.pageId == initialPageId) {
       clearData();
     }
 
@@ -57,5 +68,6 @@ class EventsController extends StateNotifier<EventsState> {
     state = state.copyWith(
       data: [],
     );
+    _read(eventsScrollPositionProvider).state = 0.0;
   }
 }

--- a/lib/pages/events_pages/event_list_view.dart
+++ b/lib/pages/events_pages/event_list_view.dart
@@ -1,66 +1,33 @@
 import 'package:event_follow/models/controllers/events_controller/events_controller.dart';
-import 'package:event_follow/models/repositories/events/events_api_request.dart';
 import 'package:event_follow/pages/events_pages/event_content_view.dart';
 import 'package:event_follow/pages/events_pages/event_empty_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../config/sort_filter_globals.dart';
 import 'event_card.dart';
 
 class EventListView extends HookWidget {
   const EventListView({
+    required this.scrollController,
+    required this.onRefresh,
     Key? key,
   }) : super(key: key);
 
+  final ScrollController scrollController;
+  final RefreshCallback onRefresh;
+
   @override
   Widget build(BuildContext context) {
-    final controller = useProvider(eventsProvider);
     final data =
         useProvider(eventsProvider.state.select((value) => value.data));
-    final meta =
-        useProvider(eventsProvider.state.select((value) => value.meta));
     final isLoading =
         useProvider(eventsProvider.state.select((value) => value.isLoading));
-    final sortFilterStateStore = useProvider(eventsConditionProvider).state;
-
     final _cardList =
         data.map((datum) => EventCard(datum.event, datum.extra)).toList();
 
-    Future<void> _onRefresh() async {
-      await controller.request(EventsApiRequest(
-          pageId: '1',
-          sort: sortFilterStateStore?.sortType.typeName,
-          time: sortFilterStateStore?.timeFilterType?.typeName,
-          friends: sortFilterStateStore?.friendFilterType?.typeName));
-    }
-
-    late final _scrollController = () {
-      final _scrollController = ScrollController();
-      _scrollController.addListener(() {
-        final maxScrollExtent = _scrollController.position.maxScrollExtent;
-        final currentPosition = _scrollController.position.pixels;
-        if (maxScrollExtent > 0 &&
-            (maxScrollExtent - 100.0) <= currentPosition) {
-          final currentPage = meta?.currentPage ?? 1;
-          final totalPages = meta?.totalPages ?? 1;
-          if (!isLoading && _hasNextPaging(currentPage, totalPages)) {
-            final nextPageId = (meta?.currentPage ?? 1) + 1;
-
-            controller.request(EventsApiRequest(
-                pageId: nextPageId.toString(),
-                sort: sortFilterStateStore?.sortType.typeName,
-                time: sortFilterStateStore?.timeFilterType?.typeName,
-                friends: sortFilterStateStore?.friendFilterType?.typeName));
-          }
-        }
-      });
-      return _scrollController;
-    }();
-
     if (!isLoading && data.isEmpty) {
-      return EventEmptyView(onRefresh: _onRefresh);
+      return EventEmptyView(onRefresh: onRefresh);
     }
 
     if (isLoading && data.isEmpty) {
@@ -70,12 +37,8 @@ class EventListView extends HookWidget {
     }
 
     return EventContentView(
-        onRefresh: _onRefresh,
-        scrollController: _scrollController,
+        onRefresh: onRefresh,
+        scrollController: scrollController,
         cardList: _cardList);
-  }
-
-  bool _hasNextPaging(int currentPage, int totalPages) {
-    return currentPage < totalPages;
   }
 }

--- a/lib/pages/events_pages/events_page.dart
+++ b/lib/pages/events_pages/events_page.dart
@@ -2,6 +2,7 @@ import 'package:event_follow/config/sort_filter_globals.dart';
 import 'package:event_follow/models/controllers/events_controller/events_controller.dart';
 import 'package:event_follow/models/repositories/events/events_api_request.dart';
 import 'package:event_follow/pages/events_pages/event_drawer_header.dart';
+import 'package:event_follow/pages/events_pages/scroll_top_button.dart';
 import 'package:event_follow/pages/events_pages/sort_filter_button.dart';
 import 'package:event_follow/pages/events_pages/sort_filter_dialog.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +15,42 @@ class EventsPage extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final controller = useProvider(eventsProvider);
+    final meta =
+        useProvider(eventsProvider.state.select((value) => value.meta));
+    final isLoading =
+        useProvider(eventsProvider.state.select((value) => value.isLoading));
+    final sortFilterStateStore = useProvider(eventsConditionProvider).state;
+
+    late final _scrollController = () {
+      final _scrollController = ScrollController();
+      _scrollController.addListener(() {
+        final maxScrollExtent = _scrollController.position.maxScrollExtent;
+        final currentPosition = _scrollController.position.pixels;
+        if (maxScrollExtent > 0 &&
+            (maxScrollExtent - 100.0) <= currentPosition) {
+          final currentPage = meta?.currentPage ?? 1;
+          final totalPages = meta?.totalPages ?? 1;
+          if (!isLoading && _hasNextPaging(currentPage, totalPages)) {
+            final nextPageId = (meta?.currentPage ?? 1) + 1;
+
+            controller.request(EventsApiRequest(
+                pageId: nextPageId.toString(),
+                sort: sortFilterStateStore?.sortType.typeName,
+                time: sortFilterStateStore?.timeFilterType?.typeName,
+                friends: sortFilterStateStore?.friendFilterType?.typeName));
+          }
+        }
+      });
+      return _scrollController;
+    }();
+
+    Future<void> _onRefresh() async {
+      await controller.request(EventsApiRequest(
+          pageId: '1',
+          sort: sortFilterStateStore?.sortType.typeName,
+          time: sortFilterStateStore?.timeFilterType?.typeName,
+          friends: sortFilterStateStore?.friendFilterType?.typeName));
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -57,7 +94,17 @@ class EventsPage extends HookWidget {
         ],
       ),
       drawer: EventDrawerHeader(),
-      body: const EventListView(),
+      body: EventListView(
+        scrollController: _scrollController,
+        onRefresh: _onRefresh,
+      ),
+      floatingActionButton: ScrollTopButton(
+        scrollController: _scrollController,
+      ),
     );
+  }
+
+  bool _hasNextPaging(int currentPage, int totalPages) {
+    return currentPage < totalPages;
   }
 }

--- a/lib/pages/events_pages/events_page.dart
+++ b/lib/pages/events_pages/events_page.dart
@@ -26,6 +26,9 @@ class EventsPage extends HookWidget {
       _scrollController.addListener(() {
         final maxScrollExtent = _scrollController.position.maxScrollExtent;
         final currentPosition = _scrollController.position.pixels;
+
+        context.read(eventsScrollPositionProvider).state = currentPosition;
+
         if (maxScrollExtent > 0 &&
             (maxScrollExtent - 100.0) <= currentPosition) {
           final currentPage = meta?.currentPage ?? 1;
@@ -46,7 +49,7 @@ class EventsPage extends HookWidget {
 
     Future<void> _onRefresh() async {
       await controller.request(EventsApiRequest(
-          pageId: '1',
+          pageId: initialPageId,
           sort: sortFilterStateStore?.sortType.typeName,
           time: sortFilterStateStore?.timeFilterType?.typeName,
           friends: sortFilterStateStore?.friendFilterType?.typeName));
@@ -70,7 +73,7 @@ class EventsPage extends HookWidget {
                 return SortFilterDialog(
                   onChange: (store) {
                     controller.request(EventsApiRequest(
-                        pageId: '1',
+                        pageId: initialPageId,
                         sort: store.sortType.typeName,
                         time: store.timeFilterType?.typeName,
                         friends: store.friendFilterType?.typeName));

--- a/lib/pages/events_pages/scroll_top_button.dart
+++ b/lib/pages/events_pages/scroll_top_button.dart
@@ -21,7 +21,10 @@ class ScrollTopButton extends HookWidget {
               duration: const Duration(milliseconds: 300),
               curve: Curves.linear);
         },
-        child: const Icon(Icons.arrow_upward),
+        child: const Icon(
+          Icons.keyboard_arrow_up,
+          size: 40,
+        ),
       ),
     );
   }

--- a/lib/pages/events_pages/scroll_top_button.dart
+++ b/lib/pages/events_pages/scroll_top_button.dart
@@ -1,5 +1,7 @@
+import 'package:event_follow/models/controllers/events_controller/events_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ScrollTopButton extends HookWidget {
   const ScrollTopButton({required this.scrollController});
@@ -8,8 +10,11 @@ class ScrollTopButton extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final topScrollButtonVisilibity =
+        useProvider(eventsTopScrollButtonVisibilityProvider);
+
     return Visibility(
-      visible: true,
+      visible: topScrollButtonVisilibity,
       child: FloatingActionButton(
         onPressed: () {
           scrollController.animateTo(0,

--- a/lib/pages/events_pages/scroll_top_button.dart
+++ b/lib/pages/events_pages/scroll_top_button.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class ScrollTopButton extends HookWidget {
+  const ScrollTopButton({required this.scrollController});
+
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Visibility(
+      visible: true,
+      child: FloatingActionButton(
+        onPressed: () {
+          scrollController.animateTo(0,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.linear);
+        },
+        child: const Icon(Icons.arrow_upward),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 概要

イベント一覧のトップスクロール用のボタンを追加する。

# 変更内容

- イベント一覧にFloatActionButtonを追加
  - ボタン押下でイベント一覧のトップにスクロール
- スクロールの位置が一定の位置を超えた場合にボタンを表示

# 関連issue

#143 
