### PR TITLE
feat: READMEにBitriseのCIのバッチを表示 [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # イベントフォロー
 
+<div align="left">
+<img src="https://app.bitrise.io/app/425ec2b2c214208c/status.svg?token=yENcdcSOspwIIqOKuxdUXg&branch=main" alt="属性" title="タイトル">
+</div>
+
 イベントフォローは、自分の興味の方向に近い技術イベントを見逃してしまう問題を解決したい、技術イベント発見サービスです。ユーザーは Twitterの友達がシェアしたDoorkeeper、connpassのイベントを発見することができ、キーワードで検索することとは違い、検索せずに自分の興味の方向に近いイベントを発見できることが特徴です。
 
 # 機能一覧


### PR DESCRIPTION
# 概要

README.mdにBitriseのCIのバッジを表示する。

# 変更内容

REAMe.mdの先頭にバッジを左揃えで表示するようにした。

# 関連issue
