### PR TITLE
fix: レイアウト不正の不具合を修正 [ci skip]

### DIFF
--- a/lib/pages/events_pages/following_tweets_list_view.dart
+++ b/lib/pages/events_pages/following_tweets_list_view.dart
@@ -82,7 +82,9 @@ class FollowingTweetsListView extends HookWidget {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Row(
+                              Wrap(
+                                alignment: WrapAlignment.start,
+                                crossAxisAlignment: WrapCrossAlignment.center,
                                 children: [
                                   Text(tweet.user.name,
                                       style: TextStyle(

--- a/lib/pages/events_pages/friends_footer.dart
+++ b/lib/pages/events_pages/friends_footer.dart
@@ -40,8 +40,10 @@ class FriendsFooter extends HookWidget {
 
     return Container(
       padding: const EdgeInsets.all(10),
-      child: Row(
-        mainAxisSize: MainAxisSize.max,
+      width: double.infinity,
+      child: Wrap(
+        alignment: WrapAlignment.start,
+        runSpacing: 5,
         children: [
           GestureDetector(
             onTap: () {
@@ -76,36 +78,34 @@ class FriendsFooter extends HookWidget {
               ),
             ),
           ),
-          Row(
-            children: friends.map((friend) {
-              return Container(
-                  margin: const EdgeInsets.only(right: 5),
-                  child: GestureDetector(
-                    onTap: () {
-                      launch('https://twitter.com/${friend.screenName}');
-                    },
-                    child: ClipRRect(
-                      borderRadius: const BorderRadius.all(Radius.circular(50)),
-                      child: CachedNetworkImage(
-                        imageUrl: friend.profileImage,
-                        placeholder: (context, url) => Container(
+          ...friends.map((friend) {
+            return Container(
+                margin: const EdgeInsets.only(right: 5),
+                child: GestureDetector(
+                  onTap: () {
+                    launch('https://twitter.com/${friend.screenName}');
+                  },
+                  child: ClipRRect(
+                    borderRadius: const BorderRadius.all(Radius.circular(50)),
+                    child: CachedNetworkImage(
+                      imageUrl: friend.profileImage,
+                      placeholder: (context, url) => Container(
+                        color: const Color(0xffd7d7d8),
+                        width: 30,
+                        height: 30,
+                      ),
+                      errorWidget: (_, __, dynamic ___) {
+                        return Container(
                           color: const Color(0xffd7d7d8),
                           width: 30,
                           height: 30,
-                        ),
-                        errorWidget: (_, __, dynamic ___) {
-                          return Container(
-                            color: const Color(0xffd7d7d8),
-                            width: 30,
-                            height: 30,
-                          );
-                        },
-                        height: 30,
-                      ),
+                        );
+                      },
+                      height: 30,
                     ),
-                  ));
-            }).toList(),
-          )
+                  ),
+                ));
+          }).toList()
         ],
       ),
     );


### PR DESCRIPTION
# 概要

友達一覧のアイコンやツイートのスクリーン名/ユーザーIDのテキストがレイアウトに収まらない場合に、折り返されない不具合を修正する。

# 変更内容

- 友達一覧のアイコンを折り返すようにした。
- ツイートのスクリーン名/ユーザーIDのテキストを折り返すようにした。

# 関連issue

#159
#158 
