### PR TITLE
fix: イベントの友達数の背景色を変更

### DIFF
--- a/lib/pages/events_pages/friends_footer.dart
+++ b/lib/pages/events_pages/friends_footer.dart
@@ -66,7 +66,7 @@ class FriendsFooter extends HookWidget {
               width: 30,
               height: 30,
               decoration: BoxDecoration(
-                color: const Color(0xfff0f1f5),
+                color: const Color(0xffebe4df),
                 border: Border.all(
                   color: const Color(0xffc1c1c1),
                   width: 1,


### PR DESCRIPTION
# 概要

イベントの友達数の背景色を変更する。

# 変更内容
イベントの友達数の背景色をWebサイトと同じ色に合わせた。

# 関連issue
なし
