### PR TITLE
fix: イベント開催日の文字間隔を修正 [ci skip]

### DIFF
--- a/lib/pages/events_pages/event_held_view.dart
+++ b/lib/pages/events_pages/event_held_view.dart
@@ -45,7 +45,7 @@ class EventHeldView extends HookWidget {
                   child: Center(
                     child: Text(
                       event.startedAt.convertToEventDateFormat(),
-                      style: const TextStyle(fontSize: 16),
+                      style: const TextStyle(fontSize: 16, letterSpacing: 2),
                     ),
                   ),
                 )),


### PR DESCRIPTION
# 概要

イベント開催日の文字間隔を修正する

# 変更内容

TextウィジェットにletterSpacingを指定した。

# 関連issue
