### PR TITLE
fix: イベント開催のステータス表示の修正

### DIFF
--- a/lib/pages/events_pages/event_held_view.dart
+++ b/lib/pages/events_pages/event_held_view.dart
@@ -70,7 +70,7 @@ class EventHeldView extends HookWidget {
     final startAt = event.startedAt;
     final endAt = event.endedAt;
 
-    final now = DateTime.now();
+    final now = DateTime.now().toUtc();
     final nextDate = now.add(const Duration(days: 1));
     if (now.compareTo(startAt) >= 0 && now.compareTo(endAt) <= 0) {
       return const EventHeldStatus(label: '開催中', color: Color(0xfffd5c63));


### PR DESCRIPTION

# 変更内容

イベント開始時間のUTCと現在時間のローカル時間で計算し、ステータス表示がおかしいため、UTF時間で計算するように変更

# 関連issue

#173 