### PR TITLE
fix: sort by とfilter byのラベル名を変更

### DIFF
--- a/lib/pages/events_pages/sort_filter_dialog.dart
+++ b/lib/pages/events_pages/sort_filter_dialog.dart
@@ -108,11 +108,11 @@ class SortFilterDialog extends HookWidget {
                           children: const [
                             SizedBox(
                               width: 100,
-                              child: Center(child: Text('Sort by')),
+                              child: Center(child: Text('並び替え')),
                             ),
                             SizedBox(
                               width: 100,
-                              child: Center(child: Text('Filter by')),
+                              child: Center(child: Text('絞り込み')),
                             ),
                           ],
                         ),


### PR DESCRIPTION
# 概要

sort byとfilter byのラベル名を日本語に変更する

# 変更内容

sort by → 並び替え
filter by → 絞り込み

# 関連issue
